### PR TITLE
networkx2nars.py: now compatible with nars2networkx 

### DIFF
--- a/nars2networkx/test.pl
+++ b/nars2networkx/test.pl
@@ -40,7 +40,7 @@ $command = shift;
 if($command eq 't1')
 {
 	$filename = shift;
-	$cmd = "time ./nars2networkx.py data/$filename";
+	$cmd = "time python3 nars2networkx.py data/$filename";
 	execute($cmd);
 	$lines = `cat data/$filename |wc -l`;
 	print "total number of input lines: $lines\n";

--- a/networkx2nars/networkx2nars.py
+++ b/networkx2nars/networkx2nars.py
@@ -1,6 +1,8 @@
 #REDUCTED#
 import networkx as nx
-def networkx2nars(G:nx.MultiGraph, include_questions:None):
+import sys
+
+def networkx2nars(G:nx.MultiGraph, include_questions = "", old_translation=True):
     #This function receives a networkx multigraph and translates it to Narsese
     #It attaches questions if include_question has comma-separated concepts as a string.
     #E.g., include_questions ='car,dog'
@@ -8,35 +10,46 @@ def networkx2nars(G:nx.MultiGraph, include_questions:None):
     name=""
     relation=""
     #Translate attributes with string values only. 
-    for n in list(G.nodes(data=True)):
-        name=n[0]
-        for key, value in n[1].items():
-            if(not str.isdigit(str(value))):
-                nars_st = nars_st+"<"+name+"-->"+str(value)+">.\n"
+    if old_translation: #Whether to use data key to form inheritances instead of what the exporter from Narsese to graph uses, namely edges
+        for n in list(G.nodes(data=True)):
+            name=n[0]
+            for key, value in n[1].items():
+                if(not str.isdigit(str(value))):
+                    nars_st = nars_st+"<"+name+" --> "+str(value)+">.\n"
     
     #Translate relations and add them to the nars_st 
     if(nx.is_directed(G)): #Relations in a directed graph are not symmetric
         for obj1,obj2,r in list(G.edges(data=True)):
             rel_name = r['relation']
-            relation = relation + "<(*, "+obj1+", " +obj2+")-->"+rel_name+">.\n"
+            if rel_name != "-->":
+                relation = relation + "<(*, "+obj1+", " +obj2+") --> "+rel_name+">.\n"
+            else:
+                relation = "<" + obj1 + " --> " + obj2 + ">.\n"
     nars_st = nars_st+relation
     
     ### Append nars_st with questions
-    if(include_questions!=None):
+    if(include_questions != ""):
         q_concepts=include_questions.split(',')
         q_str=""
         for n in list(G.nodes(data=True)):
               name=n[0]
               for q_c in q_concepts:
-                  q_str = q_str+ "<"+name+"-->"+q_c+">?\n" 
+                  q_str = q_str+ "<"+name+" --> "+q_c+">?\n" 
         nars_st = nars_st + q_str   
     
     return nars_st
     
 if __name__ == "__main__":
     G = nx.MultiDiGraph()
-    G=nx.read_graphml('test.graphml')
-    include_questions="product,shelf"
+    G=nx.read_graphml('test.graphml' if (len(sys.argv) <= 1) else sys.argv[1]) #first argument can be a custom graphml file
+    include_questions="" if (len(sys.argv) <= 2 or sys.argv[2] == "OldTranslation") else sys.argv[2] #include question terms as second argument, but not if OldTranslation command param is used here
+    UseOldTranslation = "OldTranslation" in sys.argv #OldTranslation command param, can be at arbitrary location
+    if len(sys.argv) <= 1: #backward compatibility: if there is no parameter used, go back to "product, shelf" and old translation mode
+        include_questions = "product,shelf"
+        UseOldTranslation = True
+    #Hence, "python3 networkx2nars.py test.graphml product,shelf OldTranslation" is the same as "python3 networkx2nars.py"
+    #recommended however is the new translation mode which is compatible with the exporter: "python3 networkx2nars.py file.graphml [questionTerms]"
     Narsese=""
-    Narsese=networkx2nars(G,include_questions)
+    Narsese=networkx2nars(G,include_questions, UseOldTranslation)
+    print(Narsese)
     #REDUCTED#


### PR DESCRIPTION
...unless old translation mode is used which is left there for backwards compatibility and used by default if the new arguments to specify file, question terms and translation mode aren't used.
Also translating inheritance relations is compatible with nars2networkx now, while translating the NAL-4 relations wasn't changed.